### PR TITLE
feat: Access, Refresh 토큰 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 
     // JWT
     implementation("com.auth0:java-jwt:4.4.0")
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/freewave/domain/FreeWaveApplication.java
+++ b/src/main/java/com/freewave/domain/FreeWaveApplication.java
@@ -2,9 +2,8 @@ package com.freewave.domain;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 public class FreeWaveApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/freewave/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/freewave/domain/auth/controller/AuthController.java
@@ -1,16 +1,20 @@
 package com.freewave.domain.auth.controller;
 
+import com.freewave.domain.auth.dto.TokenPair;
 import com.freewave.domain.auth.dto.request.SignupRequest;
 import com.freewave.domain.auth.dto.response.SignupResponse;
 import com.freewave.domain.auth.service.AuthService;
+import com.freewave.domain.auth.service.TokenService;
+import com.freewave.domain.common.security.JwtUtil;
+import com.freewave.domain.common.security.PrincipalDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,10 +22,33 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final TokenService tokenService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/v1/auth/signup")
     public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest signupRequest) {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(authService.signup(signupRequest));
+    }
+
+    @PostMapping("/v1/auth/refresh")
+    public ResponseEntity<TokenPair> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = jwtUtil.getAccessTokenFromHeader(request);
+        String refreshToken = jwtUtil.resolveTokenFromCookie(request);
+
+        TokenPair oldTokens = new TokenPair(accessToken, refreshToken);
+        TokenPair newTokens = tokenService.refreshTokens(oldTokens);
+
+        jwtUtil.addAccessTokenToHeader(response, newTokens.getAccessToken());
+        jwtUtil.addRefreshTokenToCookie(response, newTokens.getRefreshToken());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(newTokens);
+    }
+
+    @GetMapping("/v1/test")
+    public void test(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        System.out.println(principalDetails.getUser().getId());
+        System.out.println(principalDetails.getUser().getUserRole());
+        System.out.println(principalDetails.getUser().getNickname());
     }
 }

--- a/src/main/java/com/freewave/domain/auth/dto/TokenPair.java
+++ b/src/main/java/com/freewave/domain/auth/dto/TokenPair.java
@@ -1,0 +1,12 @@
+package com.freewave.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenPair {
+
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/java/com/freewave/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/freewave/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,22 @@
+package com.freewave.domain.auth.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@NoArgsConstructor
+@RedisHash(value = "refresh_token", timeToLive = 14 * 24 * 60 * 60)
+public class RefreshToken {
+
+    @Id
+    private Long userId;
+
+    private String refreshToken;
+
+    public RefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/freewave/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/freewave/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.freewave.domain.auth.repository;
+
+import com.freewave.domain.auth.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByRefreshToken(String token);
+
+    void deleteByRefreshToken(String token);
+}

--- a/src/main/java/com/freewave/domain/auth/service/TokenService.java
+++ b/src/main/java/com/freewave/domain/auth/service/TokenService.java
@@ -1,0 +1,11 @@
+package com.freewave.domain.auth.service;
+
+import com.freewave.domain.auth.dto.TokenPair;
+import com.freewave.domain.auth.entity.RefreshToken;
+
+public interface TokenService {
+
+    void saveRefreshToken(RefreshToken refreshToken);
+
+    TokenPair refreshTokens(TokenPair tokenPair);
+}

--- a/src/main/java/com/freewave/domain/auth/service/TokenServiceImpl.java
+++ b/src/main/java/com/freewave/domain/auth/service/TokenServiceImpl.java
@@ -1,0 +1,61 @@
+package com.freewave.domain.auth.service;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.freewave.domain.auth.dto.TokenPair;
+import com.freewave.domain.auth.entity.RefreshToken;
+import com.freewave.domain.auth.repository.RefreshTokenRepository;
+import com.freewave.domain.common.exception.AnomalyDetectionException;
+import com.freewave.domain.common.exception.InvalidTokenException;
+import com.freewave.domain.common.security.JwtUtil;
+import com.freewave.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TokenServiceImpl implements TokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    @Transactional
+    public void saveRefreshToken(RefreshToken refreshToken) {
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    @Override
+    @Transactional
+    public TokenPair refreshTokens(TokenPair tokenPair) {
+        DecodedJWT info = jwtUtil.getUserInfoFromToken(tokenPair.getAccessToken());
+        Long userId = Long.valueOf(info.getSubject());
+
+        RefreshToken refreshToken = refreshTokenRepository.findById(userId).orElseThrow(
+                () -> new InvalidTokenException("Not found refreshToken")
+        );
+
+        if (!refreshToken.getRefreshToken().equals(tokenPair.getRefreshToken())) {
+            log.info("Anomaly Detection");
+
+            userService.lockAccount(userId);
+            refreshTokenRepository.delete(refreshToken);
+
+            throw new AnomalyDetectionException("Anomaly Detection");
+        } else {
+            String nickname = info.getClaim("nickname").asString();
+            String role = info.getClaim("role").asString();
+
+            String newAccessToken = jwtUtil.createAccessToken(userId, nickname, role);
+            String newRefreshToken = jwtUtil.createRefreshToken(userId);
+
+            refreshTokenRepository.save(new RefreshToken(userId, newRefreshToken));
+
+            return new TokenPair(newAccessToken, newRefreshToken);
+        }
+    }
+}

--- a/src/main/java/com/freewave/domain/common/dto/ExceptionResponse.java
+++ b/src/main/java/com/freewave/domain/common/dto/ExceptionResponse.java
@@ -1,0 +1,22 @@
+package com.freewave.domain.common.dto;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+
+@Getter
+public class ExceptionResponse {
+
+    private final String timestamp = String.valueOf(LocalDateTime.now());
+    private final HttpStatus status;
+    private final String error;
+    private final URI path;
+
+    public ExceptionResponse(HttpStatus status, String error, URI path) {
+        this.status = status;
+        this.error = error;
+        this.path = path;
+    }
+}

--- a/src/main/java/com/freewave/domain/common/exception/AnomalyDetectionException.java
+++ b/src/main/java/com/freewave/domain/common/exception/AnomalyDetectionException.java
@@ -1,0 +1,7 @@
+package com.freewave.domain.common.exception;
+
+public class AnomalyDetectionException extends RuntimeException {
+    public AnomalyDetectionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/freewave/domain/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/freewave/domain/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.freewave.domain.common.exception;
+
+import com.freewave.domain.common.dto.ExceptionResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 400 Bad Request (잘못된 요청)
+    @ExceptionHandler(InvalidRequestException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ExceptionResponse> handleInvalidRequest(InvalidRequestException e, HttpServletRequest request) {
+        return ResponseEntity
+                .badRequest()
+                .body(new ExceptionResponse(HttpStatus.BAD_REQUEST, e.getMessage(), URI.create(request.getRequestURI())));
+    }
+
+    // 401 Unauthorized (유효하지 않은 토큰)
+    @ExceptionHandler({InvalidTokenException.class, JwtTokenExpiredException.class})
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ResponseEntity<ExceptionResponse> handleTokenException(RuntimeException e, HttpServletRequest request) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new ExceptionResponse(HttpStatus.UNAUTHORIZED, e.getMessage(), URI.create(request.getRequestURI())));
+    }
+
+    // 403 Forbidden (계정 잠금, 접근 거부)
+    @ExceptionHandler(AnomalyDetectionException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ResponseEntity<ExceptionResponse> handleAnomalyDetection(AnomalyDetectionException e, HttpServletRequest request) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(new ExceptionResponse(HttpStatus.FORBIDDEN, e.getMessage(), URI.create(request.getRequestURI())));
+    }
+
+    // 500 Internal Server Error (기타 예외)
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<ExceptionResponse> handleAll(Exception e, HttpServletRequest request) {
+        return ResponseEntity
+                .internalServerError()
+                .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error: " + e.getMessage(), URI.create(request.getRequestURI())));
+    }
+}

--- a/src/main/java/com/freewave/domain/common/exception/InvalidTokenException.java
+++ b/src/main/java/com/freewave/domain/common/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.freewave.domain.common.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/freewave/domain/common/security/JwtUtil.java
+++ b/src/main/java/com/freewave/domain/common/security/JwtUtil.java
@@ -4,7 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.*;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.freewave.domain.common.exception.InvalidRequestException;
+import com.freewave.domain.common.exception.InvalidTokenException;
 import com.freewave.domain.common.exception.JwtTokenExpiredException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -33,39 +34,25 @@ public class JwtUtil {
     @Value("${jwt.refresh.secret.key}")
     private String refreshSecretKey;
 
-    private final long ACCESS_TOKEN_EXPIRATION = 60 * 30 * 1000L; // 30분
-    private final long REFRESH_TOKEN_EXPIRATION = 60 * 60 * 24 * 14 * 1000L; // 2주
-
-    public String createAccessToken(PrincipalDetails principalDetails) {
-
+    public String createAccessToken(Long userId, String nickname, String role) {
         return BEARER_PREFIX + JWT.create()
-                .withSubject(principalDetails.getUser().getId().toString())
-                .withExpiresAt(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION))
-                .withClaim("role", principalDetails.getUser().getUserRole().getAuthority())
+                .withSubject(userId.toString())
+                .withExpiresAt(new Date(System.currentTimeMillis() + 1000L)) // 30분
+                .withClaim("nickname", nickname)
+                .withClaim("role", role)
                 .sign(Algorithm.HMAC512(accessSecretKey));
     }
 
-    public String createRefreshToken(PrincipalDetails principalDetails) {
-
+    public String createRefreshToken(Long userId) {
         return BEARER_PREFIX + JWT.create()
-                .withSubject(principalDetails.getUser().getId().toString())
-                .withExpiresAt(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION))
-                .withClaim("role", principalDetails.getUser().getUserRole().getAuthority())
+                .withSubject(userId.toString())
+                .withExpiresAt(new Date(System.currentTimeMillis() + 60 * 60 * 24 * 14 * 1000L)) // 2주
                 .sign(Algorithm.HMAC512(refreshSecretKey));
     }
 
-    // Access Token을 쿠키에 저장 (Bearer prefix 없이)
-    public void addAccessTokenToCookie(HttpServletResponse response, String token) {
-        token = URLEncoder.encode(token, StandardCharsets.UTF_8).replaceAll("\\+", "%20"); // Cookie Value 에는 공백이 불가능해서 encoding 진행
-
-        Cookie cookie = new Cookie(AUTHORIZATION_HEADER, token);
-        cookie.setHttpOnly(true);  // XSS 공격 방지를 위해 HttpOnly 설정. HttpOnly로 설정하여 JavaScript에서 접근 불가
-        cookie.setMaxAge(24 * 60 * 60);  // Access Token 쿠키의 만료 시간 1일로 설정 (Access Token 만료 시간과는 별개)
-        cookie.setPath("/");  // 쿠키의 경로를 루트로 설정
-        cookie.setSecure(false);
-        cookie.setDomain("localhost"); // 실제 운영 환경에서는 setDomain을 배포된 서버의 도메인(예: "example.com")으로 설정해야 함
-        cookie.setAttribute("SameSite", "Strict"); // 크로스 도메인 요청 허용
-        response.addCookie(cookie);
+    // Access Token 헤더 설정
+    public void addAccessTokenToHeader(HttpServletResponse response, String accessToken) {
+        response.addHeader(AUTHORIZATION_HEADER, accessToken);
     }
 
     // Refresh Token 쿠키 설정
@@ -73,20 +60,29 @@ public class JwtUtil {
         refreshToken = URLEncoder.encode(refreshToken, StandardCharsets.UTF_8).replaceAll("\\+", "%20"); // Cookie Value 에는 공백이 불가능해서 encoding 진행
         Cookie cookie = new Cookie(REFRESH_TOKEN_HEADER, refreshToken);
         cookie.setHttpOnly(true);        // XSS 공격 방지를 위해 HttpOnly 설정. HttpOnly로 설정하여 JavaScript에서 접근 불가
-        cookie.setMaxAge(24 * 60 * 60);  // Refresh Token 쿠키의 만료 시간 1일로 설정 (Refresh Token 만료 시간과는 별개)
+        cookie.setMaxAge(60 * 60 * 24 * 14);  // Refresh Token 쿠키의 만료 시간 1일로 설정 (Refresh Token 만료 시간과는 별개)
         cookie.setPath("/");             // 쿠키의 경로를 루트로 설정
-        cookie.setSecure(false);
-        cookie.setDomain("localhost"); // 실제 운영 환경에서는 setDomain을 배포된 서버의 도메인(예: "example.com")으로 설정해야 함
-        cookie.setAttribute("SameSite", "Strict"); // 크로스 도메인 요청 허용
+        cookie.setSecure(true); // 운영환경에서는 true(https)
+//        cookie.setDomain("localhost"); // 실제 운영 환경에서는 setDomain을 배포된 서버의 도메인(예: "example.com")으로 설정해야 함
+        cookie.setAttribute("SameSite", "None"); // 프론트와 백엔드가 도메인이 다르면 Lax 또는 None
         response.addCookie(cookie);
     }
 
-    // 쿠키에서 Access Token 추출
+    // header 에서 JWT 가져오기
+    public String getAccessTokenFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // 쿠키에서 Refresh Token 추출
     public String resolveTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                if (cookie.getName().equals(AUTHORIZATION_HEADER)) {
+                if (cookie.getName().equals(REFRESH_TOKEN_HEADER)) {
                     // 쿠키 값 디코딩
                     return java.net.URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8);
                 }
@@ -98,26 +94,32 @@ public class JwtUtil {
     // 토큰 검증 및 디코딩
     public DecodedJWT validateToken(String token) {
         token = token.replace(BEARER_PREFIX, ""); // Bearer 접두사 제거
+
         try {
             return JWT
                     .require(Algorithm.HMAC512(accessSecretKey))
                     .build()
                     .verify(token); // 검증 성공 시 DecodedJWT 반환
         } catch (TokenExpiredException e) {
-            log.error("Expired JWT token, 만료된 JWT token 입니다.");
             throw new JwtTokenExpiredException("Expired JWT token", e); // 예외를 던져 호출부에서 처리 가능하도록 함
         } catch (SignatureVerificationException e) {
-            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
-            throw new InvalidRequestException("Invalid JWT signature");
+            throw new InvalidTokenException("Invalid JWT signature");
         } catch (AlgorithmMismatchException e) {
-            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
-            throw new InvalidRequestException("Unsupported JWT token");
+            throw new InvalidTokenException("Unsupported JWT token");
         } catch (JWTDecodeException | IllegalArgumentException e) {
-            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
-            throw new InvalidRequestException("Invalid JWT claims");
+            throw new InvalidTokenException("Invalid JWT claims");
         } catch (JWTVerificationException e) {
-            log.error("JWT verification failed, 일반적인 검증 오류");
-            throw new InvalidRequestException("JWT verification failed");
+            throw new InvalidTokenException("JWT verification failed");
+        }
+    }
+
+    public DecodedJWT getUserInfoFromToken(String token) {
+        token = token.replace(BEARER_PREFIX, ""); // Bearer 접두사 제거
+
+        try {
+            return JWT.decode(token); // 만료된 토큰도 강제로 디코딩
+        } catch (Exception e) {
+            throw new InvalidTokenException("토큰 파싱 실패");
         }
     }
 

--- a/src/main/java/com/freewave/domain/common/security/PrincipalDetails.java
+++ b/src/main/java/com/freewave/domain/common/security/PrincipalDetails.java
@@ -46,7 +46,7 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public boolean isAccountNonLocked() {
-        return true;
+        return user.getIsAccountNonLocked();
     }
 
     @Override

--- a/src/main/java/com/freewave/domain/user/entity/User.java
+++ b/src/main/java/com/freewave/domain/user/entity/User.java
@@ -18,6 +18,7 @@ public class User extends Timestamped {
     private String email;
     private String password;
     private String nickname;
+    private Boolean isAccountNonLocked;
 
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
@@ -27,9 +28,24 @@ public class User extends Timestamped {
         this.password = password;
         this.userRole = userRole;
         this.nickname = nickname;
+        isAccountNonLocked = true;
+    }
+
+    private User(Long userId, UserRole userRole, String nickname) {
+        id = userId;
+        this.userRole = userRole;
+        this.nickname = nickname;
     }
 
     public static User of(String username, String password, UserRole userRole, String nickname) {
         return new User(username, password, userRole, nickname);
+    }
+
+    public static User fromToken(Long userId, UserRole userRole, String nickname) {
+        return new User(userId, userRole, nickname);
+    }
+
+    public void accountLock() {
+        isAccountNonLocked = false;
     }
 }

--- a/src/main/java/com/freewave/domain/user/enums/UserRole.java
+++ b/src/main/java/com/freewave/domain/user/enums/UserRole.java
@@ -19,7 +19,7 @@ public enum UserRole {
         return Arrays.stream(UserRole.values())
                 .filter(r -> r.name().equalsIgnoreCase(role))
                 .findFirst()
-                .orElseThrow(() -> new InvalidRequestException("Invalid UerRole"));
+                .orElseThrow(() -> new InvalidRequestException("Invalid UserRole"));
     }
 
     public static class Authority {

--- a/src/main/java/com/freewave/domain/user/service/UserService.java
+++ b/src/main/java/com/freewave/domain/user/service/UserService.java
@@ -8,5 +8,9 @@ public interface UserService {
 
     User isValidEmail(String email);
 
+    User isValidUser(Long userId);
+
     void isExistsEmail(String email);
+
+    void lockAccount(Long userId);
 }

--- a/src/main/java/com/freewave/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/freewave/domain/user/service/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.freewave.domain.user.entity.User;
 import com.freewave.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -27,9 +28,23 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public User isValidUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> new InvalidRequestException("Not found user")
+        );
+    }
+
+    @Override
     public void isExistsEmail(String email) {
         if (userRepository.existsByEmail(email)) {
             throw new InvalidRequestException("Email already exists");
         }
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void lockAccount(Long userId) {
+        User user = isValidUser(userId);
+        user.accountLock();
     }
 }


### PR DESCRIPTION
Access, Refresh 토큰을 구현하여 토큰 탈취에 대비

Access 토큰을 헤더에 넣도록 구현
Access Token이 쿠키에 있으면, 악의적인 사이트에서 사용자의 인증을 도용할 수 있다(CSRF 공격). 
Access Token을 Authorization 헤더에 담아 보내면, 브라우저의 자동 전송(쿠키)로 인한 예기치 않은 노출을 막을 수 있다.
Access Token은 노출돼도 금방 만료되므로, 클라이언트 메모리(상태관리)에만 저장하고 필요할 때만 헤더에 넣는 것이 일반적이다.

Refresh 토큰은 쿠키에 담도록 구현
Refresh Token만 HttpOnly, Secure 쿠키에 저장
Refresh 토큰과 Access 토큰의 Secrey Key를 다르게 하여 CSRF 공격에 대비하여 Refresh 토큰을 Access 토큰처럼 사용하는 것을 방지한다. 이 방식에서는 클라이언트가 Refresh Token을 직접 다루지 않고, 쿠키에만 저장되어 있기 때문에 XSS 위험이 줄어든다.

해커가 토큰을 탈취하여 먼저 Access 토큰을 갱신하는 경우 RTR(Refresh Token Rotation) 기법을 사용하여 뒤늦게 사용자가 Access 토큰을 갱신하는 경우 즉, 한 명의 사용자에 여러 refresh token 값이 저장되는 경우 이상 현상 감지로 해당 사용자의 계정에 lock을 건다. 이런식으로 최대한 토큰 탈취에  대비

또한, JWT의 장점인 stateless를 최대한 살리기 위해 Access 토큰을 갱신할 때는 이전에 사용하던 Access 토큰의 유저 정보를 불러와 갱신하여 최대한 RDB로부터의 사용자 조회 횟수를 줄임

최초 로그인 이후 유저 정보를 RDB에서 조회하는 경우는 이상 현상이 감지되어 lock을 걸 때 뿐이다.