### PR TITLE
feat: 기술 스택 수정 기능 추가

### DIFF
--- a/src/main/java/com/freewave/domain/resume/controller/ResumeController.java
+++ b/src/main/java/com/freewave/domain/resume/controller/ResumeController.java
@@ -1,0 +1,34 @@
+package com.freewave.domain.resume.controller;
+
+import com.freewave.domain.common.security.PrincipalDetails;
+import com.freewave.domain.resume.dto.request.ResumeRequest;
+import com.freewave.domain.resume.dto.response.ResumeResponse;
+import com.freewave.domain.resume.service.ResumeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ResumeController {
+
+    private final ResumeService resumeService;
+
+    @PutMapping("/v1/resumes/skills")
+    public ResponseEntity<ResumeResponse> updateSkill(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody ResumeRequest resumeRequest
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(resumeService.updateSkill(principalDetails, resumeRequest));
+    }
+
+    @GetMapping("/v1/resumes/skills")
+    public ResponseEntity<ResumeResponse> getSkillList(
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(resumeService.getUserSkillList(principalDetails.getUser().getId()));
+    }
+}

--- a/src/main/java/com/freewave/domain/resume/dto/request/ResumeRequest.java
+++ b/src/main/java/com/freewave/domain/resume/dto/request/ResumeRequest.java
@@ -1,0 +1,15 @@
+package com.freewave.domain.resume.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResumeRequest {
+
+    private List<String> skills;
+}

--- a/src/main/java/com/freewave/domain/resume/dto/response/ResumeResponse.java
+++ b/src/main/java/com/freewave/domain/resume/dto/response/ResumeResponse.java
@@ -1,0 +1,13 @@
+package com.freewave.domain.resume.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class ResumeResponse {
+
+    private final List<String> skillList;
+}

--- a/src/main/java/com/freewave/domain/resume/entity/Resume.java
+++ b/src/main/java/com/freewave/domain/resume/entity/Resume.java
@@ -1,4 +1,30 @@
 package com.freewave.domain.resume.entity;
 
+import com.freewave.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor
 public class Resume {
+
+    @Id
+    private Long id;
+
+    @MapsId
+    @OneToOne
+    @JoinColumn(name = "user_id", unique = true)
+    private User user;
+
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ResumeSkill> resumeSkillList = new ArrayList<>();
+
+    public Resume(User user) {
+        this.user = user;
+    }
 }

--- a/src/main/java/com/freewave/domain/resume/entity/ResumeSkill.java
+++ b/src/main/java/com/freewave/domain/resume/entity/ResumeSkill.java
@@ -1,0 +1,28 @@
+package com.freewave.domain.resume.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class ResumeSkill {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "skill_id", nullable = false)
+    private Skill skill;
+
+    public ResumeSkill(Resume resume, Skill skill) {
+        this.resume = resume;
+        this.skill = skill;
+    }
+}

--- a/src/main/java/com/freewave/domain/resume/entity/Skill.java
+++ b/src/main/java/com/freewave/domain/resume/entity/Skill.java
@@ -1,0 +1,29 @@
+package com.freewave.domain.resume.entity;
+
+import com.freewave.domain.resume.enums.TechStack;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Skill {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private TechStack techStack;
+
+    @OneToMany(mappedBy = "skill", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ResumeSkill> resumeSkillList = new ArrayList<>();
+
+    public Skill(TechStack techStack) {
+        this.techStack = techStack;
+    }
+}

--- a/src/main/java/com/freewave/domain/resume/enums/TechStack.java
+++ b/src/main/java/com/freewave/domain/resume/enums/TechStack.java
@@ -1,0 +1,249 @@
+package com.freewave.domain.resume.enums;
+
+import com.freewave.domain.common.exception.InvalidRequestException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum TechStack {
+    // 프로그래밍 언어
+    JAVA("Java"),
+    PYTHON("Python"),
+    JAVASCRIPT("JavaScript"),
+    TYPESCRIPT("TypeScript"),
+    KOTLIN("Kotlin"),
+    SWIFT("Swift"),
+    GO("Go"),
+    RUST("Rust"),
+    C("C"),
+    CPP("C++"),
+    CSHARP("C#"),
+    PHP("PHP"),
+    RUBY("Ruby"),
+    SCALA("Scala"),
+    DART("Dart"),
+    HASKELL("Haskell"),
+    PERL("Perl"),
+    R("R"),
+    GROOVY("Groovy"),
+    CLOJURE("Clojure"),
+
+    // 프론트엔드 프레임워크 및 라이브러리
+    REACT("React.js"),
+    ANGULAR("Angular"),
+    VUE("Vue.js"),
+    NEXT("Next.js"),
+    SVELTE("Svelte"),
+    JQUERY("jQuery"),
+    BACKBONE("Backbone.js"),
+    EMBER("Ember.js"),
+    PREACT("Preact"),
+    SOLID_JS("SolidJS"),
+    GATSBY("Gatsby.js"),
+    NUXT("Nuxt.js"),
+    REMIX("Remix"),
+    ASTRO("Astro"),
+
+    // 백엔드 프레임워크 및 라이브러리
+    SPRING("Spring Framework"),
+    SPRING_BOOT("Spring Boot"),
+    DJANGO("Django"),
+    FLASK("Flask"),
+    EXPRESS("Express.js"),
+    LARAVEL("Laravel"),
+    DOTNET(".NET"),
+    RUBY_ON_RAILS("Ruby on Rails"),
+    NESTJS("NestJS"),
+    FASTAPI("FastAPI"),
+    PHOENIX("Phoenix"),
+    SYMFONY("Symfony"),
+    ASPNET("ASP.NET"),
+    STRAPI("Strapi"),
+
+    // CSS 프레임워크 및 도구
+    TAILWIND("Tailwind CSS"),
+    BOOTSTRAP("Bootstrap"),
+    SASS("Sass"),
+    LESS("Less"),
+    STYLED_COMPONENTS("Styled Components"),
+    EMOTION("Emotion"),
+    BULMA("Bulma"),
+    FOUNDATION("Foundation"),
+    MATERIALIZE("Materialize CSS"),
+    CHAKRA_UI("Chakra UI"),
+    MATERIAL_UI("Material UI"),
+    ANT_DESIGN("Ant Design"),
+    SEMANTIC_UI("Semantic UI"),
+
+    // UI/UX 디자인 도구
+    FIGMA("Figma"),
+    SKETCH("Sketch"),
+    ADOBE_XD("Adobe XD"),
+    INVISION("InVision"),
+    ZEPLIN("Zeplin"),
+    ADOBE_ILLUSTRATOR("Adobe Illustrator"),
+    ADOBE_PHOTOSHOP("Adobe Photoshop"),
+    PROTOPIE("ProtoPie"),
+    AXURE("Axure RP"),
+    FRAMER("Framer"),
+    BALSAMIQ("Balsamiq"),
+    PRINCIPLE("Principle"),
+    ADOBE_AFTER_EFFECTS("Adobe After Effects"),
+    UIZARD("Uizard"),
+    KHROMA("Khroma"),
+    ATTENTION_INSIGHT("Attention Insight"),
+    ADOBE_FIREFLY("Adobe Firefly"),
+    VISILY("Visily"),
+
+    // 데이터베이스
+    MYSQL("MySQL"),
+    POSTGRESQL("PostgreSQL"),
+    ORACLE("Oracle"),
+    MONGODB("MongoDB"),
+    REDIS("Redis"),
+    ELASTICSEARCH("Elasticsearch"),
+    MARIADB("MariaDB"),
+    MSSQL("Microsoft SQL Server"),
+    DYNAMODB("Amazon DynamoDB"),
+    CASSANDRA("Apache Cassandra"),
+    COUCHDB("CouchDB"),
+    NEO4J("Neo4j"),
+    FIREBASE_FIRESTORE("Firebase Firestore"),
+    SQLITE("SQLite"),
+    INFLUXDB("InfluxDB"),
+
+    // 인프라 및 DevOps
+    DOCKER("Docker"),
+    KUBERNETES("Kubernetes"),
+    JENKINS("Jenkins"),
+    GITHUB_ACTIONS("GitHub Actions"),
+    TERRAFORM("Terraform"),
+    ANSIBLE("Ansible"),
+    GITLAB_CI("GitLab CI/CD"),
+    CIRCLE_CI("Circle CI"),
+    TRAVIS_CI("Travis CI"),
+    PROMETHEUS("Prometheus"),
+    GRAFANA("Grafana"),
+    NGINX("NGINX"),
+    APACHE("Apache HTTP Server"),
+    PUPPET("Puppet"),
+    CHEF("Chef"),
+
+    // 클라우드
+    AWS("Amazon Web Services"),
+    AZURE("Microsoft Azure"),
+    GCP("Google Cloud Platform"),
+    HEROKU("Heroku"),
+    DIGITAL_OCEAN("Digital Ocean"),
+    IBM_CLOUD("IBM Cloud"),
+    ALIBABA_CLOUD("Alibaba Cloud"),
+    ORACLE_CLOUD("Oracle Cloud"),
+    VERCEL("Vercel"),
+    NETLIFY("Netlify"),
+    CLOUDFLARE("Cloudflare"),
+    LINODE("Linode"),
+
+    // 모바일
+    ANDROID("Android"),
+    IOS("iOS"),
+    REACT_NATIVE("React Native"),
+    FLUTTER("Flutter"),
+    XAMARIN("Xamarin"),
+    IONIC("Ionic"),
+    CORDOVA("Apache Cordova"),
+    KOTLIN_MULTIPLATFORM("Kotlin Multiplatform"),
+    SWIFT_UI("SwiftUI"),
+    JETPACK_COMPOSE("Jetpack Compose"),
+
+    // 테스트 도구
+    JEST("Jest"),
+    MOCHA("Mocha"),
+    CYPRESS("Cypress"),
+    SELENIUM("Selenium"),
+    JUNIT("JUnit"),
+    TESTNG("TestNG"),
+    PUPPETEER("Puppeteer"),
+    JASMINE("Jasmine"),
+    ENZYME("Enzyme"),
+    TESTING_LIBRARY("Testing Library"),
+    PLAYWRIGHT("Playwright"),
+
+    // 상태 관리
+    REDUX("Redux"),
+    MOBX("MobX"),
+    RECOIL("Recoil"),
+    ZUSTAND("Zustand"),
+    JOTAI("Jotai"),
+    VUEX("Vuex"),
+    PINIA("Pinia"),
+    CONTEXT_API("React Context API"),
+    NGXS("NGXS"),
+
+    // 웹 개발 도구
+    WEBPACK("Webpack"),
+    VITE("Vite"),
+    PARCEL("Parcel"),
+    ROLLUP("Rollup"),
+    BABEL("Babel"),
+    ESLINT("ESLint"),
+    PRETTIER("Prettier"),
+    STORYBOOK("Storybook"),
+    CHROME_DEVTOOLS("Chrome DevTools"),
+    POSTMAN("Postman"),
+    VS_CODE("Visual Studio Code"),
+    WEBSTORM("WebStorm"),
+
+    // 3D 및 그래픽
+    THREE_JS("Three.js"),
+    WEBGL("WebGL"),
+    UNITY("Unity"),
+    UNREAL_ENGINE("Unreal Engine"),
+    BLENDER("Blender"),
+    D3("D3.js"),
+    CANVAS_API("Canvas API"),
+    SVG("SVG"),
+    BABYLON_JS("Babylon.js"),
+    PIXIJS("PixiJS"),
+
+    // AR/VR
+    ARKIT("ARKit"),
+    ARCORE("ARCore"),
+    VUFORIA("Vuforia"),
+    OCULUS_SDK("Oculus SDK"),
+    AFRAME("A-Frame"),
+    WEBXR("WebXR"),
+
+    // 기타
+    GIT("Git"),
+    GRAPHQL("GraphQL"),
+    KAFKA("Apache Kafka"),
+    HADOOP("Apache Hadoop"),
+    SPARK("Apache Spark"),
+    WEBSOCKET("WebSocket"),
+    REST_API("REST API"),
+    GRPC("gRPC"),
+    OAUTH("OAuth"),
+    JWT("JSON Web Token"),
+    MICRO_FRONTENDS("Micro Frontends"),
+    HEADLESS_CMS("Headless CMS"),
+    PWA("Progressive Web App"),
+    WEB_COMPONENTS("Web Components"),
+    WEBASSEMBLY("WebAssembly"),
+    SERVERLESS("Serverless"),
+    JAMSTACK("JAMstack"),
+    OPENAI_API("OpenAI API"),
+    WEB3("Web3.js"),
+    BLOCKCHAIN("Blockchain");
+
+    private final String displayName;
+
+    public static TechStack of(String techStack) {
+        return Arrays.stream(TechStack.values())
+                .filter(ts -> ts.name().equalsIgnoreCase(techStack))
+                .findFirst()
+                .orElseThrow(() -> new InvalidRequestException("Invalid TechStack: " + techStack));
+    }
+}

--- a/src/main/java/com/freewave/domain/resume/repository/ResumeSkillRepository.java
+++ b/src/main/java/com/freewave/domain/resume/repository/ResumeSkillRepository.java
@@ -1,0 +1,13 @@
+package com.freewave.domain.resume.repository;
+
+import com.freewave.domain.resume.entity.ResumeSkill;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ResumeSkillRepository extends JpaRepository<ResumeSkill, Long> {
+    List<ResumeSkill> findAllByResume_Id(Long resumeId);
+
+    Optional<ResumeSkill> findByResume_IdAndSkill_Id(Long resumeId, Long skillId);
+}

--- a/src/main/java/com/freewave/domain/resume/repository/SkillRepository.java
+++ b/src/main/java/com/freewave/domain/resume/repository/SkillRepository.java
@@ -1,0 +1,12 @@
+package com.freewave.domain.resume.repository;
+
+import com.freewave.domain.resume.entity.Skill;
+import com.freewave.domain.resume.enums.TechStack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SkillRepository extends JpaRepository<Skill, Long> {
+
+    Optional<Skill> findByTechStack(TechStack techStack);
+}

--- a/src/main/java/com/freewave/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/freewave/domain/resume/service/ResumeService.java
@@ -1,0 +1,11 @@
+package com.freewave.domain.resume.service;
+
+import com.freewave.domain.common.security.PrincipalDetails;
+import com.freewave.domain.resume.dto.request.ResumeRequest;
+import com.freewave.domain.resume.dto.response.ResumeResponse;
+
+public interface ResumeService {
+    ResumeResponse updateSkill(PrincipalDetails principalDetails, ResumeRequest responseRequest);
+
+    ResumeResponse getUserSkillList(Long resumeId);
+}

--- a/src/main/java/com/freewave/domain/resume/service/ResumeServiceImpl.java
+++ b/src/main/java/com/freewave/domain/resume/service/ResumeServiceImpl.java
@@ -1,0 +1,68 @@
+package com.freewave.domain.resume.service;
+
+import com.freewave.domain.common.exception.InvalidRequestException;
+import com.freewave.domain.common.security.PrincipalDetails;
+import com.freewave.domain.resume.dto.request.ResumeRequest;
+import com.freewave.domain.resume.dto.response.ResumeResponse;
+import com.freewave.domain.resume.entity.ResumeSkill;
+import com.freewave.domain.resume.entity.Skill;
+import com.freewave.domain.resume.enums.TechStack;
+import com.freewave.domain.resume.repository.ResumeSkillRepository;
+import com.freewave.domain.resume.repository.SkillRepository;
+import com.freewave.domain.user.entity.User;
+import com.freewave.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ResumeServiceImpl implements ResumeService {
+
+    private final ResumeSkillRepository resumeSkillRepository;
+    private final SkillRepository skillRepository;
+    private final UserService userService;
+
+    @Override
+    @Transactional
+    public ResumeResponse updateSkill(PrincipalDetails principalDetails, ResumeRequest resumeRequest) {
+        User user = userService.isValidUser(principalDetails.getUser().getId());
+
+        List<Skill> skillList = new ArrayList<>();
+        for (String skill : resumeRequest.getSkills()) {
+            skillList.add(isValidSkill(skill));
+        }
+
+        List<ResumeSkill> newResumeSkillList = new ArrayList<>();
+        for (Skill skill : skillList) {
+            if (resumeSkillRepository.findByResume_IdAndSkill_Id(user.getResume().getId(), skill.getId()).isPresent()) {
+                continue;
+            }
+            newResumeSkillList.add(new ResumeSkill(user.getResume(), skill));
+        }
+        resumeSkillRepository.saveAll(newResumeSkillList);
+
+        return getUserSkillList(user.getResume().getId());
+    }
+
+    @Override
+    public ResumeResponse getUserSkillList(Long resumeId) {
+        List<String> skillList = resumeSkillRepository.findAllByResume_Id(resumeId).
+                stream().map(resumeSkill -> resumeSkill
+                        .getSkill()
+                        .getTechStack()
+                        .getDisplayName()).toList();
+
+        return new ResumeResponse(skillList);
+    }
+
+    public Skill isValidSkill(String techStack) {
+        return skillRepository.findByTechStack(TechStack.of(techStack)).orElseThrow(
+                () -> new InvalidRequestException("Invalid tech stack")
+        );
+    }
+}

--- a/src/main/java/com/freewave/domain/user/entity/User.java
+++ b/src/main/java/com/freewave/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.freewave.domain.user.entity;
 
 import com.freewave.domain.common.Timestamped;
+import com.freewave.domain.resume.entity.Resume;
 import com.freewave.domain.user.enums.UserRole;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -26,6 +27,9 @@ public class User extends Timestamped {
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Resume resume;
+
     private User(String username, String password, UserRole userRole, String nickname, String imageUrl) {
         this.email = username;
         this.password = password;
@@ -33,6 +37,7 @@ public class User extends Timestamped {
         this.nickname = nickname;
         this.imageUrl = imageUrl;
         this.bio = "자기소개가 없습니다. 자신을 소개해보세요!";
+        resume = new Resume(this);
         isAccountNonLocked = true;
     }
 

--- a/src/test/java/com/freewave/domain/skill/SkillDummyDataTest.java
+++ b/src/test/java/com/freewave/domain/skill/SkillDummyDataTest.java
@@ -1,0 +1,31 @@
+package com.freewave.domain.skill;
+
+import com.freewave.domain.resume.entity.Skill;
+import com.freewave.domain.resume.enums.TechStack;
+import com.freewave.domain.resume.repository.SkillRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+@SpringBootTest
+public class SkillDummyDataTest {
+
+    @Autowired
+    private SkillRepository skillRepository;
+
+    @Test
+    @Transactional
+    @Commit
+    public void saveAllTechStacks() {
+        List<Skill> skillList = Arrays.stream(TechStack.values())
+                .map(Skill::new)
+                .toList();
+
+        skillRepository.saveAll(skillList);
+    }
+}


### PR DESCRIPTION
이력서-기술 스택 M:N 관계

이력서와 기술 스택 간의 M:N 관계는 다음과 같은 이유로 매우 적합하다.

- 데이터 표준화: 기술 스택은 "React", "Python", "AWS" 등 표준화된 항목들이다. M:N 관계를 통해 이러한 기술 스택을 한 번만 정의하고 여러 이력서에서 재사용할 수 있다.
- 확장성: 기술 스택에 카테고리, 버전 등의 추가 정보를 쉽게 추가할 수 있다.
- 유연성: 하나의 이력서에 여러 기술 스택을 포함할 수 있고, 하나의 기술 스택이 여러 이력서에서 사용될 수 있다.
- 데이터 중복 최소화: 동일한 기술 스택 정보가 여러 이력서에 중복되어 저장되는 것을 방지한다.

또한, 중간 테이블은 다음과 같은 장점을 제공한다.
- 각 이력서와 기술 스택 간의 관계를 명확히 표현
- 관계에 대한 추가 정보(숙련도, 경험 연수 등) 저장 가능
- 데이터 무결성 유지

+ 프로젝트 생성에서도 기술 스택을 사용하므로 이력서 뿐만아니라 프로젝트에서도 재사용이 가능하게끔 M:N으로 구현 하는 것이 적합하다고 생각한다.